### PR TITLE
Export de.schildbach.wallet.ui.WalletActivity

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -60,6 +60,7 @@
 		android:label="@string/app_name" >
 		<activity
 			android:name="de.schildbach.wallet.ui.WalletActivity"
+			android:exported="true"
 			android:configChanges="keyboard|keyboardHidden"
 			android:launchMode="singleTask"
 			android:theme="@style/My.Theme" />


### PR DESCRIPTION
Starting from API level 21 de.schildbach.wallet.ui.WalletActivity has to
be exported. Otherwise it can't be launched from the list of recent apps
if the user exited it using the back button before.