### PR TITLE
Increase normal tx fee

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1064,7 +1064,7 @@ public final class SendCoinsFragment extends Fragment
 		if (feeCategory == FeeCategory.ECONOMIC)
 			return SendRequest.DEFAULT_FEE_PER_KB;
 		else if (feeCategory == FeeCategory.NORMAL)
-			return SendRequest.DEFAULT_FEE_PER_KB.multiply(5);
+			return SendRequest.DEFAULT_FEE_PER_KB.multiply(10);
 		else if (feeCategory == FeeCategory.PRIORITY)
 			return SendRequest.DEFAULT_FEE_PER_KB.multiply(20);
 		else


### PR DESCRIPTION
With full blocks coming and ongoing stress tests/spam tx with a 0.00005 fee are less likely to get mined in a resonable time. Matches the default fee in bitcoin core.