### PR TITLE
Fixed two issues that popped up when trying to compile on a fresh Ubuntu 15.10

### DIFF
--- a/wallet/README
+++ b/wallet/README
@@ -51,7 +51,7 @@ You'll need git, a Java SDK 6 (or later) and Gradle 2.4 (or later) for this. I'l
 for the package installs, which comes with slightly more recent versions.
 
 	# first time only
-	sudo apt-get install git gradle openjdk-7-jdk libstdc++6:i386
+	sudo apt-get install git gradle openjdk-7-jdk libstdc++6:i386 zlib1g:i386
 
 Get the Android SDK (Tools only) from
 
@@ -64,7 +64,7 @@ and switch to it. Use
 	tools/android update sdk --no-ui --force --filter tools
 
 	# fetch required android dependencies
-	tools/android update sdk --no-ui --force --filter build-tools-23.0.2,android-15,android-16,extra-android-m2repository
+	tools/android update sdk --no-ui --force --filter build-tools-23.0.2,android-10,android-15,android-16,extra-android-m2repository
 
 to download the necessary API level.
 


### PR DESCRIPTION
Fixed two issues that popped up when trying to compile on a fresh Ubuntu 15.10 system: apparently,
- i386 libz is needed by aapt
- android-10 is needed somewhere in the build process (possibly used by a dependency package)