### PR TITLE
Move to a native Material theme

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -6,10 +6,7 @@
 	android:versionCode="234"
 	android:versionName="4.44-lollipop-test" >
 
-	<uses-sdk
-		android:minSdkVersion="15"
-		android:targetSdkVersion="21"
-		tools:ignore="OldTargetApi" />
+	<uses-sdk android:minSdkVersion="21" />
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	package="de.schildbach.wallet_test"
 	android:installLocation="internalOnly"
 	android:versionCode="234"
-	android:versionName="4.44-test" >
+	android:versionName="4.44-lollipop-test" >
 
 	<uses-sdk
 		android:minSdkVersion="15"

--- a/wallet/res/drawable/action_bar_background.xml
+++ b/wallet/res/drawable/action_bar_background.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" >
-
-	<gradient
-		android:angle="90"
-		android:endColor="#222"
-		android:startColor="#111" />
-
-</shape>

--- a/wallet/res/layout/wallet_activity_bottom_include.xml
+++ b/wallet/res/layout/wallet_activity_bottom_include.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	android:background="@drawable/action_bar_background"
+	android:background="@color/primary_material_dark"
 	android:divider="@drawable/divider_dark"
 	android:orientation="vertical"
 	android:showDividers="middle" >

--- a/wallet/res/values/colors.xml
+++ b/wallet/res/values/colors.xml
@@ -32,4 +32,8 @@
 	<color name="scan_result_view">#b0000000</color>
 	<color name="scan_result_dots">#c099cc00</color>
 
+	<!-- Theme -->
+	<color name="accent_material_light">#3f51b5</color>
+	<color name="primary_material_dark">#1a1a1a</color>
+
 </resources>

--- a/wallet/res/values/styles.xml
+++ b/wallet/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="My.Theme" parent="@android:style/Theme.Holo.Light.DarkActionBar">
+	<style name="My.Theme" parent="@android:style/Theme.Material.Light.DarkActionBar">
 		<item name="android:actionBarStyle">@style/My.Widget.ActionBar</item>
 		<item name="android:actionModeStyle">@style/My.Widget.ActionMode</item>
 		<item name="android:actionMenuTextColor">@color/fg_network</item>
@@ -12,6 +12,9 @@
 		<item name="android:autoCompleteTextViewStyle">@style/My.Widget.AutoCompleteTextView</item>
 		<item name="android:checkboxStyle">@style/My.Widget.CompoundButton.CheckBox</item>
 		<item name="android:spinnerStyle">@style/My.Widget.Spinner</item>
+		<item name="android:colorAccent">@color/accent_material_light</item>
+		<item name="android:colorPrimary">@color/primary_material_dark</item>
+		<item name="android:alertDialogTheme">@style/My.Theme.Dialog</item>
 	</style>
 
 	<style name="My.Theme.ChildActivity" parent="@style/My.Theme">
@@ -19,12 +22,14 @@
 		<item name="android:homeAsUpIndicator">@drawable/action_bar_up_indicator</item>
 	</style>
 
-	<style name="My.Theme.Fullscreen" parent="@android:style/Theme.Holo.NoActionBar.Fullscreen" />
+	<style name="My.Theme.Fullscreen" parent="@android:style/Theme.Material.NoActionBar.Fullscreen" />
 
-	<style name="My.Theme.Dialog" parent="@android:style/Theme.Holo.Light.Dialog" />
+	<style name="My.Theme.Dialog" parent="@android:style/Theme.Material.Light.Dialog.Alert">
+		<!-- Needs to be duplicated since this doesn't inherit from My.Theme -->
+		<item name="android:colorAccent">@color/accent_material_light</item>
+	</style>
 
-	<style name="My.Widget.ActionBar" parent="@android:style/Widget.Holo.Light.ActionBar.Solid.Inverse">
-		<item name="android:background">@drawable/action_bar_background</item>
+	<style name="My.Widget.ActionBar" parent="@android:style/Widget.Material.Light.ActionBar.Solid">
 		<item name="android:titleTextStyle">@style/My.TextAppearance.Widget.ActionBar.Title</item>
 		<item name="android:subtitleTextStyle">@style/My.TextAppearance.Widget.ActionBar.Subtitle</item>
 		<item name="android:displayOptions">showTitle</item>
@@ -34,81 +39,81 @@
 		<item name="android:displayOptions">homeAsUp|showTitle</item>
 	</style>
 
-	<style name="My.TextAppearance.Widget.ActionBar.Title" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Title">
+	<style name="My.TextAppearance.Widget.ActionBar.Title" parent="@android:style/TextAppearance.Material.Widget.ActionBar.Title">
 		<item name="android:textColor">@color/fg_network_significant</item>
 		<item name="android:textStyle">bold</item>
 		<item name="android:shadowColor">@android:color/black</item>
 		<item name="android:shadowRadius">1</item>
 	</style>
 
-	<style name="My.TextAppearance.Widget.ActionBar.Subtitle" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Subtitle">
+	<style name="My.TextAppearance.Widget.ActionBar.Subtitle" parent="@android:style/TextAppearance.Material.Widget.ActionBar.Subtitle">
 		<item name="android:textColor">@color/fg_network_insignificant</item>
 		<item name="android:textStyle">normal</item>
 	</style>
 
-	<style name="My.Widget.ActionButton" parent="@android:style/Widget.Holo.ActionButton">
+	<style name="My.Widget.ActionButton" parent="@android:style/Widget.Material.ActionButton">
 		<item name="android:drawablePadding">6dp</item>
 	</style>
 
-	<style name="My.Widget.ActionButton.Overflow" parent="@android:style/Widget.Holo.ActionButton.Overflow">
+	<style name="My.Widget.ActionButton.Overflow" parent="@android:style/Widget.Material.ActionButton.Overflow">
 		<item name="android:src">@drawable/ic_more_vert_white_24dp</item>
 	</style>
 
-	<style name="My.Widget.ActionMode" parent="@android:style/Widget.Holo.Light.ActionMode.Inverse">
+	<style name="My.Widget.ActionMode" parent="@android:style/Widget.Material.Light.ActionMode">
 		<item name="android:background">@drawable/action_mode_background</item>
 		<item name="android:titleTextStyle">@style/My.TextAppearance.Widget.ActionMode.Title</item>
 		<item name="android:subtitleTextStyle">@style/My.TextAppearance.Widget.ActionMode.Subtitle</item>
 	</style>
 
-	<style name="My.TextAppearance.Widget.ActionMode.Title" parent="@android:style/TextAppearance.Holo.Widget.ActionMode.Title">
+	<style name="My.TextAppearance.Widget.ActionMode.Title" parent="@android:style/TextAppearance.Material.Widget.ActionMode.Title">
 		<item name="android:textColor">@android:color/white</item>
 		<item name="android:textStyle">bold</item>
 		<item name="android:shadowColor">@android:color/black</item>
 		<item name="android:shadowRadius">1</item>
 	</style>
 
-	<style name="My.TextAppearance.Widget.ActionMode.Subtitle" parent="@android:style/TextAppearance.Holo.Widget.ActionMode.Subtitle">
+	<style name="My.TextAppearance.Widget.ActionMode.Subtitle" parent="@android:style/TextAppearance.Material.Widget.ActionMode.Subtitle">
 		<item name="android:textColor">@android:color/white</item>
 		<item name="android:textStyle">normal</item>
 	</style>
 
-	<style name="My.Widget.TextView" parent="@android:style/Widget.Holo.Light.TextView">
+	<style name="My.Widget.TextView" parent="@android:style/Widget.Material.Light.TextView">
 		<item name="android:textColor">@color/fg_significant</item>
 		<item name="android:textSize">@dimen/font_size_normal</item>
 	</style>
 
-	<style name="My.Widget.EditText" parent="@android:style/Widget.Holo.Light.EditText">
+	<style name="My.Widget.EditText" parent="@android:style/Widget.Material.Light.EditText">
 		<item name="android:textColor">@color/fg_significant</item>
 		<item name="android:textSize">@dimen/font_size_normal</item>
 	</style>
 
-	<style name="My.Widget.AutoCompleteTextView" parent="@android:style/Widget.Holo.Light.AutoCompleteTextView">
+	<style name="My.Widget.AutoCompleteTextView" parent="@android:style/Widget.Material.Light.AutoCompleteTextView">
 		<item name="android:textColor">@color/fg_significant</item>
 		<item name="android:textSize">@dimen/font_size_normal</item>
 	</style>
 
-	<style name="My.Widget.Button.Borderless" parent="@android:style/Widget.Holo.Button.Borderless">
+	<style name="My.Widget.Button.Borderless" parent="@android:style/Widget.Material.Button.Borderless">
 		<item name="android:paddingLeft">8dp</item>
 		<item name="android:paddingRight">8dp</item>
 		<item name="android:drawablePadding">8dp</item>
 	</style>
 
-	<style name="My.Widget.Button.Borderless.Unpadded" parent="@android:style/Widget.Holo.Button.Borderless">
+	<style name="My.Widget.Button.Borderless.Unpadded" parent="@android:style/Widget.Material.Button.Borderless">
 		<item name="android:padding">0px</item>
 		<item name="android:drawablePadding">0px</item>
 	</style>
 
-	<style name="My.Widget.Button.Borderless.Small" parent="@android:style/Widget.Holo.Button.Borderless.Small">
+	<style name="My.Widget.Button.Borderless.Small" parent="@android:style/Widget.Material.Button.Borderless.Small">
 		<item name="android:minWidth">40dp</item>
 		<item name="android:minHeight">40dp</item>
 	</style>
 
-	<style name="My.Widget.CompoundButton.CheckBox" parent="@android:style/Widget.Holo.Light.CompoundButton.CheckBox">
+	<style name="My.Widget.CompoundButton.CheckBox" parent="@android:style/Widget.Material.Light.CompoundButton.CheckBox">
 		<item name="android:textColor">@color/fg_significant</item>
 		<item name="android:textSize">@dimen/font_size_normal</item>
 	</style>
 
-	<style name="My.Widget.Spinner" parent="@android:style/Widget.Holo.Light.Spinner">
+	<style name="My.Widget.Spinner" parent="@android:style/Widget.Material.Light.Spinner">
 		<item name="android:textColor">@color/fg_significant</item>
 		<item name="android:textSize">@dimen/font_size_normal</item>
 	</style>

--- a/wallet/res/xml-v16/wallet_balance_widget.xml
+++ b/wallet/res/xml-v16/wallet_balance_widget.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-	android:initialLayout="@layout/wallet_balance_widget_content"
-	android:minHeight="60dp"
-	android:minResizeWidth="132dp"
-	android:minWidth="294dp"
-	android:previewImage="@drawable/widget_preview"
-	android:resizeMode="horizontal"
-	android:updatePeriodMillis="1800000" />

--- a/wallet/res/xml/wallet_balance_widget.xml
+++ b/wallet/res/xml/wallet_balance_widget.xml
@@ -2,6 +2,8 @@
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
 	android:initialLayout="@layout/wallet_balance_widget_content"
 	android:minHeight="60dp"
+	android:minResizeWidth="132dp"
 	android:minWidth="294dp"
 	android:previewImage="@drawable/widget_preview"
+	android:resizeMode="horizontal"
 	android:updatePeriodMillis="1800000" />

--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -138,14 +138,7 @@ public final class Constants
 	public static final long LAST_USAGE_THRESHOLD_JUST_MS = DateUtils.HOUR_IN_MILLIS;
 	public static final long LAST_USAGE_THRESHOLD_RECENTLY_MS = 2 * DateUtils.DAY_IN_MILLIS;
 
-	public static final int SDK_JELLY_BEAN = 16;
-	public static final int SDK_JELLY_BEAN_MR2 = 18;
-	public static final int SDK_LOLLIPOP = 21;
-
-	public static final int SDK_DEPRECATED_BELOW = Build.VERSION_CODES.ICE_CREAM_SANDWICH;
-
-	public static final boolean BUG_OPENSSL_HEARTBLEED = Build.VERSION.SDK_INT == Constants.SDK_JELLY_BEAN
-			&& Build.VERSION.RELEASE.startsWith("4.1.1");
+	public static final int SDK_DEPRECATED_BELOW = Build.VERSION_CODES.LOLLIPOP;
 
 	public static final int MEMORY_CLASS_LOWEND = 48;
 }

--- a/wallet/src/de/schildbach/wallet/ui/DialogBuilder.java
+++ b/wallet/src/de/schildbach/wallet/ui/DialogBuilder.java
@@ -23,12 +23,10 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface.OnClickListener;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
-import de.schildbach.wallet.Constants;
 import de.schildbach.wallet_test.R;
 
 /**
@@ -50,7 +48,7 @@ public class DialogBuilder extends AlertDialog.Builder
 
 	public DialogBuilder(final Context context)
 	{
-		super(context, Build.VERSION.SDK_INT < Constants.SDK_LOLLIPOP ? AlertDialog.THEME_HOLO_LIGHT : AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+		super(context, AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
 
 		this.customTitle = LayoutInflater.from(context).inflate(R.layout.dialog_title, null);
 		this.iconView = (ImageView) customTitle.findViewById(android.R.id.icon);

--- a/wallet/src/de/schildbach/wallet/ui/DialogBuilder.java
+++ b/wallet/src/de/schildbach/wallet/ui/DialogBuilder.java
@@ -48,7 +48,7 @@ public class DialogBuilder extends AlertDialog.Builder
 
 	public DialogBuilder(final Context context)
 	{
-		super(context, AlertDialog.THEME_DEVICE_DEFAULT_LIGHT);
+		super(context);
 
 		this.customTitle = LayoutInflater.from(context).inflate(R.layout.dialog_title, null);
 		this.iconView = (ImageView) customTitle.findViewById(android.R.id.icon);

--- a/wallet/src/de/schildbach/wallet/ui/ExchangeRatesFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/ExchangeRatesFragment.java
@@ -32,6 +32,7 @@ import android.content.Loader;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.database.Cursor;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -40,6 +41,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.ResourceCursorAdapter;
 import android.widget.SearchView;
@@ -155,6 +157,11 @@ public final class ExchangeRatesFragment extends FancyListFragment implements On
 		inflater.inflate(R.menu.exchange_rates_fragment_options, menu);
 
 		final SearchView searchView = (SearchView) menu.findItem(R.id.exchange_rates_options_search).getActionView();
+		final int id = searchView.getContext().getResources().getIdentifier("android:id/search_src_text", null, null);
+		final View searchInput = searchView.findViewById(id);
+		if (searchInput instanceof EditText) {
+			((EditText)searchInput).setTextColor(Color.WHITE);
+		}
 		searchView.setOnQueryTextListener(new OnQueryTextListener()
 		{
 			@Override

--- a/wallet/src/de/schildbach/wallet/ui/RequestCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/RequestCoinsFragment.java
@@ -50,7 +50,6 @@ import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
 import android.nfc.NfcEvent;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.widget.CardView;
 import android.text.SpannableStringBuilder;
@@ -113,8 +112,6 @@ public final class RequestCoinsFragment extends Fragment implements NfcAdapter.C
 	private CurrencyCalculatorLink amountCalculatorLink;
 
 	private static final int ID_RATE_LOADER = 0;
-
-	private static boolean ENABLE_BLUETOOTH_LISTENING = Build.VERSION.SDK_INT >= Constants.SDK_JELLY_BEAN_MR2;
 
 	private static final Logger log = LoggerFactory.getLogger(RequestCoinsFragment.class);
 
@@ -208,14 +205,14 @@ public final class RequestCoinsFragment extends Fragment implements NfcAdapter.C
 		amountCalculatorLink = new CurrencyCalculatorLink(btcAmountView, localAmountView);
 
 		acceptBluetoothPaymentView = (CheckBox) view.findViewById(R.id.request_coins_accept_bluetooth_payment);
-		acceptBluetoothPaymentView.setVisibility(ENABLE_BLUETOOTH_LISTENING && bluetoothAdapter != null ? View.VISIBLE : View.GONE);
-		acceptBluetoothPaymentView.setChecked(ENABLE_BLUETOOTH_LISTENING && bluetoothAdapter != null && bluetoothAdapter.isEnabled());
+		acceptBluetoothPaymentView.setVisibility(bluetoothAdapter != null ? View.VISIBLE : View.GONE);
+		acceptBluetoothPaymentView.setChecked(bluetoothAdapter != null && bluetoothAdapter.isEnabled());
 		acceptBluetoothPaymentView.setOnCheckedChangeListener(new OnCheckedChangeListener()
 		{
 			@Override
 			public void onCheckedChanged(final CompoundButton buttonView, final boolean isChecked)
 			{
-				if (ENABLE_BLUETOOTH_LISTENING && bluetoothAdapter != null && isChecked)
+				if (bluetoothAdapter != null && isChecked)
 				{
 					if (bluetoothAdapter.isEnabled())
 					{
@@ -274,7 +271,7 @@ public final class RequestCoinsFragment extends Fragment implements NfcAdapter.C
 
 		loaderManager.initLoader(ID_RATE_LOADER, null, rateLoaderCallbacks);
 
-		if (ENABLE_BLUETOOTH_LISTENING && bluetoothAdapter != null && bluetoothAdapter.isEnabled() && acceptBluetoothPaymentView.isChecked())
+		if (bluetoothAdapter != null && bluetoothAdapter.isEnabled() && acceptBluetoothPaymentView.isChecked())
 			startBluetoothListening();
 
 		updateView();

--- a/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
@@ -55,7 +55,6 @@ import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
@@ -77,7 +76,6 @@ import android.widget.TextView;
 import android.widget.ViewAnimator;
 import de.schildbach.wallet.AddressBookProvider;
 import de.schildbach.wallet.Configuration;
-import de.schildbach.wallet.Constants;
 import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet.ui.TransactionsAdapter.Warning;
 import de.schildbach.wallet.ui.send.RaiseFeeDialogFragment;
@@ -554,8 +552,7 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
 	{
 		if (config.remindBackup())
 			return Warning.BACKUP;
-		else if (Build.VERSION.SDK_INT >= Constants.SDK_LOLLIPOP
-				&& devicePolicyManager.getStorageEncryptionStatus() != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE)
+		else if (devicePolicyManager.getStorageEncryptionStatus() != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE)
 			return Warning.STORAGE_ENCRYPTION;
 		else
 			return null;

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1197,17 +1197,12 @@ public final class SendCoinsFragment extends Fragment
 			amountCalculatorLink.setEnabled(state == State.INPUT && paymentIntent.mayEditAmount());
 
 			final boolean directPaymentVisible;
-			if (paymentIntent.hasPaymentUrl())
-			{
-				if (paymentIntent.isBluetoothPaymentUrl())
-					directPaymentVisible = bluetoothAdapter != null;
-				else
-					directPaymentVisible = !Constants.BUG_OPENSSL_HEARTBLEED;
-			}
+			if (paymentIntent.isBluetoothPaymentUrl())
+				directPaymentVisible = bluetoothAdapter != null;
+			else if (paymentIntent.isHttpPaymentUrl())
+				directPaymentVisible = true;
 			else
-			{
 				directPaymentVisible = false;
-			}
 			directPaymentEnableView.setVisibility(directPaymentVisible ? View.VISIBLE : View.GONE);
 			directPaymentEnableView.setEnabled(state == State.INPUT);
 
@@ -1437,7 +1432,7 @@ public final class SendCoinsFragment extends Fragment
 						// ask for permission to enable bluetooth
 						startActivityForResult(new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE), REQUEST_CODE_ENABLE_BLUETOOTH_FOR_PAYMENT_REQUEST);
 				}
-				else if (paymentIntent.hasPaymentRequestUrl() && paymentIntent.isHttpPaymentRequestUrl() && !Constants.BUG_OPENSSL_HEARTBLEED)
+				else if (paymentIntent.hasPaymentRequestUrl() && paymentIntent.isHttpPaymentRequestUrl())
 				{
 					requestPaymentRequest();
 				}
@@ -1451,7 +1446,7 @@ public final class SendCoinsFragment extends Fragment
 					if (paymentIntent.isBluetoothPaymentUrl())
 						directPaymentEnableView.setChecked(bluetoothAdapter != null && bluetoothAdapter.isEnabled());
 					else if (paymentIntent.isHttpPaymentUrl())
-						directPaymentEnableView.setChecked(!Constants.BUG_OPENSSL_HEARTBLEED);
+						directPaymentEnableView.setChecked(true);
 
 					requestFocusFirst();
 					updateView();


### PR DESCRIPTION
This is simply a move to the native Theme.Material.*, basically the same as in #276 but without all the other changes. I thought having that out of the way is a good start to continue working with the newer widgets.

- Removes the gradient from the ActionBar as Material is all flat. The color is about the median between the previous gradient colors. But maybe you want to get a bit more colorful with this branch :) 
- Introduce Indigo 500 as accent color. Of course this is up to you which color you want to choose
- Don't let DialogBuilder override the Dialog style
- Hack to have white text in SearchView. This one seems a bit ugly, but works. I hope it can be removed with a move to Toolbar.