### PR TITLE
Added Android Studio and gradle wrapper files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 .gradle/
+gradle/
+gradlew
+gradlew.bat
 build/
 local.properties
 .classpath
 .project
 .settings/
 .idea/
+*.iml
 bin/
 gen/


### PR DESCRIPTION
I added some Android Studio and gradle files to gitignore. If you'd like I can instead put up a PR [adding gradle wrapper to VCS](https://stackoverflow.com/questions/20348451/why-should-the-gradle-wrapper-be-commited-to-vcs).